### PR TITLE
Changed id for repository from "central" to "central-additional"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     
     <repositories>
         <repository>
-            <id>central</id>
+            <id>central-additional</id>
             <name>libs-release</name>
             <url>http://artifactory.aif.io/artifactory/libs-release-local</url>
         </repository>


### PR DESCRIPTION
With old id, central maven repository will not be used. And custom repository not available from outside, so this project can't be build.

Also this changes helps to solve problem with external dependencies...

But internal dependency:
```xml
        <dependency>
            <groupId>io.aif</groupId>
            <artifactId>aif-kernel</artifactId>
            <version>1.0</version>
        </dependency>
```
didn't resolved. Looks like this dependency in "additional" artifact repository that didn't available.

Also I try to build `aif-kernel` but looks like sources not synchronized. So this project can't be build.

I suggest to create one project, that will contain `aif` and `aif-kernel` together.

Sorry for my bad english, I hope you understand what I mean.